### PR TITLE
Add draft model & store tests with MainActor isolation fix

### DIFF
--- a/app-ios/BabyMeasureTests/BabyMeasureTests.swift
+++ b/app-ios/BabyMeasureTests/BabyMeasureTests.swift
@@ -6,10 +6,30 @@
 //
 
 import Testing
+import Foundation
+@testable import BabyMeasure
 
+@MainActor
 struct BabyMeasureTests {
-  @Test
-  func example() async throws {
-    // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+  @Test("Draft model initialization")
+  func draftInitialization() throws {
+    let child = ChildDraft(id: UUID(), name: "Alice", gender: .female, birthday: .now)
+    #expect(child.name == "Alice")
+    #expect(child.gender == .female)
+
+    let measurement = MeasurementDraft(id: UUID(), childId: child.id, type: .height, value: 72.4, recordedAt: .now)
+    #expect(measurement.type == .height)
+    #expect(measurement.value == 72.4)
+  }
+
+  @Test("InMemoryStore append & query")
+  func storeMutation() throws {
+    let store = InMemoryStore()
+    let child = ChildDraft(id: UUID(), name: "Bob", gender: .unspecified, birthday: .now)
+    store.add(child: child)
+    #expect(store.children.count == 1)
+    let m1 = MeasurementDraft(id: UUID(), childId: child.id, type: .weight, value: 10.2, recordedAt: .now)
+    store.add(record: m1)
+    #expect(store.measurements(for: child.id).count == 1)
   }
 }


### PR DESCRIPTION
## Summary
Adds unit tests for draft domain models (`ChildDraft`, `MeasurementDraft`) and basic `InMemoryStore` mutation/query, addressing actor isolation build failures by annotating the test container with `@MainActor`.

## Details
- Implements two tests:
  - Draft model initialization for child and measurement creation
  - InMemoryStore append & query for child + measurement
- Ensures tests interact safely with `@MainActor` isolated domain types.

## Motivation
Previously, tests failed due to main actor isolation violations when accessing properties of `ChildDraft`, `MeasurementDraft`, and `InMemoryStore`. This resolves those compile-time errors.

## Issue Link
Relates to #14 (task: initial unit test for draft models). Does not close the issue because other Phase 00 tasks remain.

## Next Steps
- Add more edge case tests (empty store, multiple measurements ordering)
- Integrate SwiftFormat check in CI once Phase 11 work starts

## Verification
Local build + tests expected to succeed after actor annotation.

