### PR TITLE
feat(storage): add SwiftData ChildEntity & MeasurementEntity models

### DIFF
--- a/app-ios/BabyMeasure/Storage/Entities.swift
+++ b/app-ios/BabyMeasure/Storage/Entities.swift
@@ -1,0 +1,40 @@
+import Foundation
+import SwiftData
+
+@Model
+public class ChildEntity {
+  @Attribute(.unique) public var id: UUID
+  public var name: String
+  public var genderRaw: String?
+  public var birthday: Date
+  public var createdAt: Date
+  public var updatedAt: Date
+  
+  public init(id: UUID = UUID(), name: String, genderRaw: String? = nil, birthday: Date, createdAt: Date = Date(), updatedAt: Date = Date()) {
+    self.id = id
+    self.name = name
+    self.genderRaw = genderRaw
+    self.birthday = birthday
+    self.createdAt = createdAt
+    self.updatedAt = updatedAt
+  }
+}
+
+@Model
+public class MeasurementEntity {
+  @Attribute(.unique) public var id: UUID
+  public var childId: UUID
+  public var typeRaw: String // height|weight|headCircumference
+  public var value: Double
+  public var recordedAt: Date
+  public var createdAt: Date
+  
+  public init(id: UUID = UUID(), childId: UUID, typeRaw: String, value: Double, recordedAt: Date, createdAt: Date = Date()) {
+    self.id = id
+    self.childId = childId
+    self.typeRaw = typeRaw
+    self.value = value
+    self.recordedAt = recordedAt
+    self.createdAt = createdAt
+  }
+}


### PR DESCRIPTION
### Summary
Adds initial SwiftData model layer for storage feature:
- `ChildEntity` with unique id, name, optional gender, birthday, timestamps
- `MeasurementEntity` capturing height/weight/head circumference measurements per child

### Rationale
Begins implementing Phase 01 (local storage foundation) enabling us to wire up persistence using SwiftData. These models represent core domain data and will later be extended with relationships and additional validation.

### Implementation Notes
- Uses `@Model` macro for SwiftData schema generation
- Unique UUID primary keys via `@Attribute(.unique)` to prevent accidental duplicates
- `typeRaw` kept as string placeholder; will evolve into a typed enum once schema migration strategy is in place

### Next Steps (Follow-up Issues)
- Define a `MeasurementType` enum + migration approach
- Add relationships (e.g., inverse relation from ChildEntity -> measurements) once we confirm query patterns
- Implement CRUD storage adapter & unit tests
- Integrate into onboarding flow for first child creation

### Checklist
- [x] Compiles locally
- [x] Models scoped as `public` for upcoming adapter/tests

Please review and suggest any schema adjustments early before more code depends on these models.
