### PR TITLE
Add export functionality and migrate chatmodes to agents

### DIFF
--- a/.github/agents/default.agent.md
+++ b/.github/agents/default.agent.md
@@ -1,0 +1,7 @@
+---
+description: 'For general purpose.'
+tools: ['vscode/getProjectSetupInfo', 'vscode/runCommand', 'execute/testFailure', 'execute/getTerminalOutput', 'execute/runInTerminal', 'execute/runTests', 'read/problems', 'read/readFile', 'read/terminalSelection', 'read/terminalLastCommand', 'edit/createDirectory', 'edit/createFile', 'edit/editFiles', 'search', 'web/fetch', 'github/*', 'github/*', 'todo']
+---
+You are a helpful assistant that helps with building a iOS app project.
+
+

--- a/.github/agents/github.agent.md
+++ b/.github/agents/github.agent.md
@@ -1,6 +1,6 @@
 ---
 description: 'Manage github issue.'
-tools: ['search', 'runCommands', 'github/github-mcp-server/*', 'usages', 'fetch', 'githubRepo']
+tools: ['execute/getTerminalOutput', 'execute/runInTerminal', 'read/readFile', 'read/terminalSelection', 'read/terminalLastCommand', 'search', 'web', 'github/*', 'github/*']
 ---
 #  instructions
 You are in GitHub mode. Your task is to manage GitHub issues, pull requests, and other repository-related activities.

--- a/.github/agents/plan-feature.agent.md
+++ b/.github/agents/plan-feature.agent.md
@@ -1,6 +1,6 @@
 ---
 description: 'Generate an implementation plan for new features or refactoring existing code.'
-tools: ['codebase', 'fetch', 'findTestFiles', 'githubRepo', 'search', 'usages']
+tools: ['read/readFile', 'search', 'web']
 ---
 # Planning mode instructions
 You are in planning mode. Your task is to generate an implementation plan for a new feature or for refactoring existing code.

--- a/.github/agents/prompt-builder.agent.md
+++ b/.github/agents/prompt-builder.agent.md
@@ -1,6 +1,6 @@
 ---
 description: 'Expert prompt engineering and validation system for creating high-quality prompts - Brought to you by microsoft/edge-ai'
-tools: ['codebase', 'editFiles', 'fetch', 'githubRepo', 'problems', 'runCommands', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'usages', 'terraform', 'Microsoft Docs', 'context7']
+tools: ['execute/getTerminalOutput', 'execute/runInTerminal', 'read/problems', 'read/readFile', 'read/terminalSelection', 'read/terminalLastCommand', 'edit/editFiles', 'search', 'web']
 ---
 
 # Prompt Builder Instructions

--- a/.github/agents/script.agent.md
+++ b/.github/agents/script.agent.md
@@ -1,6 +1,6 @@
 ---
 description: 'Improve agility for the BabyMilestones project.'
-tools: ['runCommands', 'runTasks', 'edit', 'runNotebooks', 'search', 'new', 'extensions', 'usages', 'vscodeAPI', 'problems', 'changes', 'testFailure', 'openSimpleBrowser', 'fetch', 'githubRepo', 'todos', 'runTests']
+tools: ['vscode', 'execute', 'read', 'edit', 'search', 'web', 'todo']
 ---
 The BabyMilestones project is an iOS application designed to help parents track their baby's developmental milestones. The project is built using Swift and follows modern iOS development practices.
 Your task is to assist in improving the agility by writing scripts, automating tasks, and enhancing the development workflow.

--- a/.github/chatmodes/default.chatmode.md
+++ b/.github/chatmodes/default.chatmode.md
@@ -1,7 +1,0 @@
----
-description: 'For general purpose.'
-tools: ['edit/createFile', 'edit/createDirectory', 'edit/editFiles', 'search', 'new/runVscodeCommand', 'new/getProjectSetupInfo', 'runCommands', 'XcodeBuildMCP/*', 'github/github-mcp-server/*', 'usages', 'problems', 'changes', 'testFailure', 'fetch', 'todos', 'runTests']
----
-You are a helpful assistant that helps with building a iOS app project.
-
-

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -318,11 +318,11 @@ swift run --package-path scripts hScript lint
 ```
 
 
-## Tips when working with terminal
+## When working with terminal
 
 To get output from terminal commands, you can create a temp file, and re-direct output there. For example:
 
 ```sh
-swift run --package-path scripts hScript someCommand > /tmp/output.txt
+swift run --package-path scripts hScript someCommand > output.txt
 ```     
-The output will be in `/tmp/output.txt` which you can then read.
+The output will be in `output.txt` which you can then read.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -90,5 +90,10 @@
         "eval": false,
         "Invoke-Expression": false,
         "iex": false
+    },
+    "chat.mcp.serverSampling": {
+        "BabyMilestones/.vscode/mcp.json: XcodeBuildMCP": {
+            "allowedDuringChat": true
+        }
     }
 }

--- a/app-ios/BabyMeasure/Export/ExportService.swift
+++ b/app-ios/BabyMeasure/Export/ExportService.swift
@@ -1,0 +1,219 @@
+import Foundation
+import HStorage
+
+/// Protocol defining export capabilities for child and measurement data.
+protocol Exporting {
+  /// Exports children and their measurements to CSV format.
+  /// - Parameters:
+  ///   - children: Array of children to export.
+  ///   - records: Array of measurements to export.
+  /// - Returns: URL to the temporary CSV file.
+  func exportCSV(children: [ChildEntity], records: [MeasurementEntity]) throws -> URL
+
+  /// Exports children and their measurements to JSON format.
+  /// - Parameters:
+  ///   - children: Array of children to export.
+  ///   - records: Array of measurements to export.
+  /// - Returns: URL to the temporary JSON file.
+  func exportJSON(children: [ChildEntity], records: [MeasurementEntity]) throws -> URL
+
+  /// Cleans up temporary export files older than the specified age.
+  /// - Parameter olderThan: Time interval threshold for cleanup.
+  func cleanupTemporaryFiles(olderThan: TimeInterval)
+}
+
+/// Service responsible for exporting child and measurement data to various formats.
+@MainActor
+final class ExportService: Exporting {
+  /// Errors that can occur during export operations.
+  enum ExportError: LocalizedError {
+    case fileCreationFailed
+    case encodingFailed
+
+    var errorDescription: String? {
+      switch self {
+      case .fileCreationFailed:
+        "无法创建导出文件"
+      case .encodingFailed:
+        "数据编码失败"
+      }
+    }
+  }
+
+  /// Directory for storing temporary export files.
+  private var exportDirectory: URL {
+    FileManager.default.temporaryDirectory.appending(path: "BabyMeasureExports")
+  }
+
+  /// ISO8601 formatter for dates.
+  private let dateFormatter: ISO8601DateFormatter = {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    return formatter
+  }()
+
+  init() {
+    // Ensure export directory exists
+    try? FileManager.default.createDirectory(at: exportDirectory, withIntermediateDirectories: true)
+  }
+
+  // MARK: - CSV Export
+
+  func exportCSV(children: [ChildEntity], records: [MeasurementEntity]) throws -> URL {
+    var csvContent = "child_id,name,gender,birthday,record_id,type,value,recorded_at\n"
+
+    // Build a lookup for children
+    let childLookup = Dictionary(uniqueKeysWithValues: children.map { ($0.id, $0) })
+
+    for record in records {
+      guard let child = childLookup[record.childId] else { continue }
+
+      let row = [
+        escapeCSV(child.id.uuidString),
+        escapeCSV(child.name),
+        escapeCSV(child.genderRaw ?? ""),
+        escapeCSV(dateFormatter.string(from: child.birthday)),
+        escapeCSV(record.id.uuidString),
+        escapeCSV(record.typeRaw),
+        String(record.value),
+        escapeCSV(dateFormatter.string(from: record.recordedAt)),
+      ].joined(separator: ",")
+
+      csvContent += row + "\n"
+    }
+
+    // Also include children without records
+    let recordedChildIds = Set(records.map(\.childId))
+    for child in children where !recordedChildIds.contains(child.id) {
+      let row = [
+        escapeCSV(child.id.uuidString),
+        escapeCSV(child.name),
+        escapeCSV(child.genderRaw ?? ""),
+        escapeCSV(dateFormatter.string(from: child.birthday)),
+        "", // record_id
+        "", // type
+        "", // value
+        "", // recorded_at
+      ].joined(separator: ",")
+
+      csvContent += row + "\n"
+    }
+
+    let fileName = "BabyMeasure_\(fileTimestamp()).csv"
+    let fileURL = exportDirectory.appending(path: fileName)
+
+    guard let data = csvContent.data(using: .utf8) else {
+      throw ExportError.encodingFailed
+    }
+
+    try data.write(to: fileURL, options: .atomic)
+    return fileURL
+  }
+
+  /// Escapes a string for CSV format, handling commas, quotes, and newlines.
+  private func escapeCSV(_ value: String) -> String {
+    let needsQuoting = value.contains(",") || value.contains("\"") || value.contains("\n") || value.contains("\r")
+    if needsQuoting {
+      let escaped = value.replacing("\"", with: "\"\"")
+      return "\"\(escaped)\""
+    }
+    return value
+  }
+
+  // MARK: - JSON Export
+
+  func exportJSON(children: [ChildEntity], records: [MeasurementEntity]) throws -> URL {
+    let exportData = ExportData(
+      version: "BabyMilestones-0.7",
+      exportedAt: dateFormatter.string(from: Date()),
+      children: children.map { ExportChild(from: $0) },
+      records: records.map { ExportRecord(from: $0) }
+    )
+
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+
+    let data = try encoder.encode(exportData)
+
+    let fileName = "BabyMeasure_\(fileTimestamp()).json"
+    let fileURL = exportDirectory.appending(path: fileName)
+
+    try data.write(to: fileURL, options: .atomic)
+    return fileURL
+  }
+
+  // MARK: - Cleanup
+
+  func cleanupTemporaryFiles(olderThan interval: TimeInterval = 3600) {
+    let fileManager = FileManager.default
+    guard let files = try? fileManager.contentsOfDirectory(at: exportDirectory, includingPropertiesForKeys: [.creationDateKey]) else {
+      return
+    }
+
+    let threshold = Date().addingTimeInterval(-interval)
+
+    for file in files {
+      guard let attributes = try? file.resourceValues(forKeys: [.creationDateKey]),
+            let creationDate = attributes.creationDate,
+            creationDate < threshold
+      else {
+        continue
+      }
+      try? fileManager.removeItem(at: file)
+    }
+  }
+
+  // MARK: - Helpers
+
+  private func fileTimestamp() -> String {
+    let formatter = DateFormatter()
+    formatter.dateFormat = "yyyyMMdd_HHmmss"
+    return formatter.string(from: Date())
+  }
+}
+
+// MARK: - Export Data Models
+
+/// Root structure for JSON export.
+struct ExportData: Codable {
+  let version: String
+  let exportedAt: String
+  let children: [ExportChild]
+  let records: [ExportRecord]
+}
+
+/// Child data for export.
+struct ExportChild: Codable {
+  let id: String
+  let name: String
+  let gender: String?
+  let birthday: String
+
+  init(from entity: ChildEntity) {
+    id = entity.id.uuidString
+    name = entity.name
+    gender = entity.genderRaw
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withFullDate]
+    birthday = formatter.string(from: entity.birthday)
+  }
+}
+
+/// Measurement record for export.
+struct ExportRecord: Codable {
+  let id: String
+  let childId: String
+  let type: String
+  let value: Double
+  let recordedAt: String
+
+  init(from entity: MeasurementEntity) {
+    id = entity.id.uuidString
+    childId = entity.childId.uuidString
+    type = entity.typeRaw
+    value = entity.value
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime]
+    recordedAt = formatter.string(from: entity.recordedAt)
+  }
+}

--- a/app-ios/BabyMeasure/Export/ExportView.swift
+++ b/app-ios/BabyMeasure/Export/ExportView.swift
@@ -1,0 +1,218 @@
+import HStorage
+import SwiftData
+import SwiftUI
+
+/// View for exporting child and measurement data.
+struct ExportView: View {
+  @Environment(\.modelContext) private var modelContext
+  @Environment(\.dismiss) private var dismiss
+  @Query(sort: \ChildEntity.createdAt) private var allChildren: [ChildEntity]
+
+  @State private var exportFormat: ExportFormat = .csv
+  @State private var exportScope: ExportScope = .all
+  @State private var selectedChildId: UUID?
+  @State private var exportState: ExportState = .idle
+  @State private var exportedFileURL: URL?
+
+  private let exportService = ExportService()
+
+  var body: some View {
+    NavigationStack {
+      Form {
+        formatSection
+        scopeSection
+        exportButtonSection
+      }
+      .navigationTitle("导出数据")
+      .toolbar {
+        ToolbarItem(placement: .cancellationAction) {
+          Button("取消") { dismiss() }
+        }
+      }
+    }
+  }
+
+  // MARK: - Sections
+
+  private var formatSection: some View {
+    Section {
+      Picker("导出格式", selection: $exportFormat) {
+        ForEach(ExportFormat.allCases) { format in
+          Text(format.displayName).tag(format)
+        }
+      }
+      .pickerStyle(.segmented)
+    } header: {
+      Text("格式")
+    } footer: {
+      Text(exportFormat.description)
+    }
+  }
+
+  private var scopeSection: some View {
+    Section("导出范围") {
+      Picker("范围", selection: $exportScope) {
+        Text("全部儿童").tag(ExportScope.all)
+        Text("单个儿童").tag(ExportScope.single)
+      }
+      .pickerStyle(.segmented)
+
+      if exportScope == .single {
+        if allChildren.isEmpty {
+          Text("暂无儿童数据")
+            .foregroundStyle(.secondary)
+        } else {
+          Picker("选择儿童", selection: $selectedChildId) {
+            Text("请选择").tag(nil as UUID?)
+            ForEach(allChildren) { child in
+              Text(child.name).tag(child.id as UUID?)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  @ViewBuilder private var exportButtonSection: some View {
+    Section {
+      switch exportState {
+      case .idle:
+        Button("生成导出文件", action: performExport)
+          .disabled(!canExport)
+          .frame(maxWidth: .infinity)
+
+      case .exporting:
+        HStack {
+          ProgressView()
+          Text("正在生成...")
+        }
+        .frame(maxWidth: .infinity)
+
+      case .success:
+        if let url = exportedFileURL {
+          ShareLink(item: url) {
+            Label("分享文件", systemImage: "square.and.arrow.up")
+              .frame(maxWidth: .infinity)
+          }
+
+          Button("重新生成", action: resetExport)
+            .foregroundStyle(.secondary)
+        }
+
+      case let .failure(error):
+        VStack(spacing: 8) {
+          Label("导出失败", systemImage: "exclamationmark.triangle")
+            .foregroundStyle(.red)
+          Text(error)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+          Button("重试", action: performExport)
+        }
+      }
+    }
+  }
+
+  // MARK: - Logic
+
+  private var canExport: Bool {
+    guard !allChildren.isEmpty else { return false }
+    if exportScope == .single, selectedChildId == nil {
+      return false
+    }
+    return true
+  }
+
+  private func performExport() {
+    exportState = .exporting
+
+    Task {
+      do {
+        let childrenToExport = childrenForExport()
+        let records = try fetchRecords(for: childrenToExport)
+
+        let url: URL = switch exportFormat {
+        case .csv:
+          try exportService.exportCSV(children: childrenToExport, records: records)
+        case .json:
+          try exportService.exportJSON(children: childrenToExport, records: records)
+        }
+
+        exportedFileURL = url
+        exportState = .success
+
+        // Schedule cleanup of old files
+        exportService.cleanupTemporaryFiles(olderThan: 3600)
+      } catch {
+        exportState = .failure(error.localizedDescription)
+      }
+    }
+  }
+
+  private func resetExport() {
+    exportState = .idle
+    exportedFileURL = nil
+  }
+
+  private func childrenForExport() -> [ChildEntity] {
+    switch exportScope {
+    case .all:
+      return allChildren
+    case .single:
+      guard let id = selectedChildId else { return [] }
+      return allChildren.filter { $0.id == id }
+    }
+  }
+
+  private func fetchRecords(for children: [ChildEntity]) throws -> [MeasurementEntity] {
+    let childIds = children.map(\.id)
+    let predicate = #Predicate<MeasurementEntity> { record in
+      childIds.contains(record.childId)
+    }
+    let descriptor = FetchDescriptor<MeasurementEntity>(
+      predicate: predicate,
+      sortBy: [SortDescriptor(\.recordedAt, order: .reverse)]
+    )
+    return try modelContext.fetch(descriptor)
+  }
+}
+
+// MARK: - Supporting Types
+
+enum ExportFormat: String, CaseIterable, Identifiable {
+  case csv
+  case json
+
+  var id: String { rawValue }
+
+  var displayName: String {
+    switch self {
+    case .csv: "CSV"
+    case .json: "JSON"
+    }
+  }
+
+  var description: String {
+    switch self {
+    case .csv:
+      "逗号分隔值格式，适合 Excel 等表格软件打开"
+    case .json:
+      "结构化数据格式，适合程序处理和备份"
+    }
+  }
+}
+
+enum ExportScope {
+  case all
+  case single
+}
+
+enum ExportState: Equatable {
+  case idle
+  case exporting
+  case success
+  case failure(String)
+}
+
+#Preview("ExportView", traits: .modifier(SampleData())) {
+  ExportView()
+}

--- a/app-ios/BabyMeasure/RootView.swift
+++ b/app-ios/BabyMeasure/RootView.swift
@@ -8,6 +8,7 @@ struct RootView: View {
   @State private var selectedChildState = SelectedChildState()
   @State private var showingAddChild = false
   @State private var showingAddRecord = false
+  @State private var showingExport = false
 
   var body: some View {
     @Bindable var state = selectedChildState
@@ -24,6 +25,9 @@ struct RootView: View {
       }
       .navigationTitle("记录")
       .toolbar {
+        ToolbarItemGroup(placement: .topBarLeading) {
+          Button("导出", systemImage: "square.and.arrow.up") { showingExport = true }
+        }
         ToolbarItemGroup(placement: .topBarTrailing) {
           if let child = state.current {
             NavigationLink("曲线", destination: GrowthChartView(child: child))
@@ -44,6 +48,9 @@ struct RootView: View {
         } else {
           Text("未选择儿童")
         }
+      }
+      .sheet(isPresented: $showingExport) {
+        ExportView()
       }
       .onAppear {
         if state.current == nil {

--- a/app-ios/BabyMeasureTests/ExportServiceTests.swift
+++ b/app-ios/BabyMeasureTests/ExportServiceTests.swift
@@ -1,0 +1,256 @@
+import Foundation
+import HStorage
+import Testing
+
+@testable import BabyMeasure
+
+@MainActor
+@Suite("ExportService Tests")
+struct ExportServiceTests {
+  let exportService = ExportService()
+
+  // MARK: - Test Data
+
+  func makeSampleChild(
+    id: UUID = UUID(),
+    name: String = "测试儿童",
+    genderRaw: String? = "male",
+    birthday: Date = Date()
+  ) -> ChildEntity {
+    ChildEntity(
+      id: id,
+      name: name,
+      genderRaw: genderRaw,
+      birthday: birthday
+    )
+  }
+
+  func makeSampleMeasurement(
+    id: UUID = UUID(),
+    childId: UUID,
+    typeRaw: String = "height",
+    value: Double = 75.5,
+    recordedAt: Date = Date()
+  ) -> MeasurementEntity {
+    MeasurementEntity(
+      id: id,
+      childId: childId,
+      typeRaw: typeRaw,
+      value: value,
+      recordedAt: recordedAt
+    )
+  }
+
+  // MARK: - CSV Tests
+
+  @Test("CSV export creates file with correct header")
+  func cSVBasicHeader() throws {
+    let child = makeSampleChild()
+    let record = makeSampleMeasurement(childId: child.id)
+
+    let url = try exportService.exportCSV(children: [child], records: [record])
+
+    #expect(FileManager.default.fileExists(atPath: url.path()))
+    let content = try String(contentsOf: url, encoding: .utf8)
+    #expect(content.hasPrefix("child_id,name,gender,birthday,record_id,type,value,recorded_at"))
+
+    // Cleanup
+    try? FileManager.default.removeItem(at: url)
+  }
+
+  @Test("CSV export contains correct number of data rows")
+  func cSVRowCount() throws {
+    let child = makeSampleChild()
+    let record1 = makeSampleMeasurement(childId: child.id, typeRaw: "height", value: 75.0)
+    let record2 = makeSampleMeasurement(childId: child.id, typeRaw: "weight", value: 10.5)
+
+    let url = try exportService.exportCSV(children: [child], records: [record1, record2])
+    let content = try String(contentsOf: url, encoding: .utf8)
+    let lines = content.split(separator: "\n", omittingEmptySubsequences: false)
+
+    // Header + 2 data rows
+    #expect(lines.count >= 3)
+
+    try? FileManager.default.removeItem(at: url)
+  }
+
+  @Test("CSV escapes special characters correctly")
+  func cSVEscaping() throws {
+    let child = makeSampleChild(name: "名字,带逗号")
+    let record = makeSampleMeasurement(childId: child.id)
+
+    let url = try exportService.exportCSV(children: [child], records: [record])
+    let content = try String(contentsOf: url, encoding: .utf8)
+
+    // Name with comma should be quoted
+    #expect(content.contains("\"名字,带逗号\""))
+
+    try? FileManager.default.removeItem(at: url)
+  }
+
+  @Test("CSV escapes quotes correctly")
+  func cSVQuoteEscaping() throws {
+    let child = makeSampleChild(name: "名字\"带引号")
+    let record = makeSampleMeasurement(childId: child.id)
+
+    let url = try exportService.exportCSV(children: [child], records: [record])
+    let content = try String(contentsOf: url, encoding: .utf8)
+
+    // Quotes should be doubled
+    #expect(content.contains("\"名字\"\"带引号\""))
+
+    try? FileManager.default.removeItem(at: url)
+  }
+
+  @Test("CSV includes children without records")
+  func cSVChildrenWithoutRecords() throws {
+    let child1 = makeSampleChild(name: "有记录")
+    let child2 = makeSampleChild(name: "无记录")
+    let record = makeSampleMeasurement(childId: child1.id)
+
+    let url = try exportService.exportCSV(children: [child1, child2], records: [record])
+    let content = try String(contentsOf: url, encoding: .utf8)
+
+    #expect(content.contains("有记录"))
+    #expect(content.contains("无记录"))
+
+    try? FileManager.default.removeItem(at: url)
+  }
+
+  // MARK: - JSON Tests
+
+  @Test("JSON export creates valid file")
+  func jSONBasic() throws {
+    let child = makeSampleChild()
+    let record = makeSampleMeasurement(childId: child.id)
+
+    let url = try exportService.exportJSON(children: [child], records: [record])
+
+    #expect(FileManager.default.fileExists(atPath: url.path()))
+    #expect(url.pathExtension == "json")
+
+    try? FileManager.default.removeItem(at: url)
+  }
+
+  @Test("JSON export contains correct version")
+  func jSONVersion() throws {
+    let child = makeSampleChild()
+
+    let url = try exportService.exportJSON(children: [child], records: [])
+    let data = try Data(contentsOf: url)
+    let json = try JSONDecoder().decode(ExportData.self, from: data)
+
+    #expect(json.version == "BabyMilestones-0.7")
+
+    try? FileManager.default.removeItem(at: url)
+  }
+
+  @Test("JSON export contains all children")
+  func jSONChildren() throws {
+    let child1 = makeSampleChild(name: "儿童1")
+    let child2 = makeSampleChild(name: "儿童2")
+
+    let url = try exportService.exportJSON(children: [child1, child2], records: [])
+    let data = try Data(contentsOf: url)
+    let json = try JSONDecoder().decode(ExportData.self, from: data)
+
+    #expect(json.children.count == 2)
+    #expect(json.children.map(\.name).contains("儿童1"))
+    #expect(json.children.map(\.name).contains("儿童2"))
+
+    try? FileManager.default.removeItem(at: url)
+  }
+
+  @Test("JSON export contains all records")
+  func jSONRecords() throws {
+    let child = makeSampleChild()
+    let record1 = makeSampleMeasurement(childId: child.id, typeRaw: "height", value: 75.0)
+    let record2 = makeSampleMeasurement(childId: child.id, typeRaw: "weight", value: 10.5)
+
+    let url = try exportService.exportJSON(children: [child], records: [record1, record2])
+    let data = try Data(contentsOf: url)
+    let json = try JSONDecoder().decode(ExportData.self, from: data)
+
+    #expect(json.records.count == 2)
+
+    try? FileManager.default.removeItem(at: url)
+  }
+
+  @Test("JSON record contains correct fields")
+  func jSONRecordFields() throws {
+    let child = makeSampleChild()
+    let record = makeSampleMeasurement(childId: child.id, typeRaw: "height", value: 80.5)
+
+    let url = try exportService.exportJSON(children: [child], records: [record])
+    let data = try Data(contentsOf: url)
+    let json = try JSONDecoder().decode(ExportData.self, from: data)
+
+    let exportedRecord = json.records.first!
+    #expect(exportedRecord.type == "height")
+    #expect(exportedRecord.value == 80.5)
+    #expect(exportedRecord.childId == child.id.uuidString)
+
+    try? FileManager.default.removeItem(at: url)
+  }
+
+  // MARK: - Selective Export Tests
+
+  @Test("Selective export only includes specified child")
+  func selectiveExport() throws {
+    let child1 = makeSampleChild(name: "儿童1")
+    let child2 = makeSampleChild(name: "儿童2")
+    let record1 = makeSampleMeasurement(childId: child1.id)
+    let record2 = makeSampleMeasurement(childId: child2.id)
+
+    // Export only child1
+    let url = try exportService.exportJSON(children: [child1], records: [record1])
+    let data = try Data(contentsOf: url)
+    let json = try JSONDecoder().decode(ExportData.self, from: data)
+
+    #expect(json.children.count == 1)
+    #expect(json.children.first?.name == "儿童1")
+    #expect(json.records.count == 1)
+
+    try? FileManager.default.removeItem(at: url)
+  }
+
+  // MARK: - File Existence Tests
+
+  @Test("Export file exists and is non-empty")
+  func shareFileExists() throws {
+    let child = makeSampleChild()
+    let record = makeSampleMeasurement(childId: child.id)
+
+    let csvURL = try exportService.exportCSV(children: [child], records: [record])
+    let jsonURL = try exportService.exportJSON(children: [child], records: [record])
+
+    #expect(FileManager.default.fileExists(atPath: csvURL.path()))
+    #expect(FileManager.default.fileExists(atPath: jsonURL.path()))
+
+    let csvData = try Data(contentsOf: csvURL)
+    let jsonData = try Data(contentsOf: jsonURL)
+
+    #expect(!csvData.isEmpty)
+    #expect(!jsonData.isEmpty)
+
+    try? FileManager.default.removeItem(at: csvURL)
+    try? FileManager.default.removeItem(at: jsonURL)
+  }
+
+  // MARK: - Cleanup Tests
+
+  @Test("Cleanup removes old files")
+  func cleanup() throws {
+    let child = makeSampleChild()
+
+    // Create a file
+    let url = try exportService.exportCSV(children: [child], records: [])
+    #expect(FileManager.default.fileExists(atPath: url.path()))
+
+    // Cleanup with 0 threshold should remove the file immediately
+    exportService.cleanupTemporaryFiles(olderThan: 0)
+
+    // File should be removed
+    #expect(!FileManager.default.fileExists(atPath: url.path()))
+  }
+}


### PR DESCRIPTION
Closes #40

## Summary
This PR adds data export functionality and migrates the GitHub Copilot configuration from chatmodes to the new agents format.

## Changes

### Export Feature
- Add ExportService for exporting child measurement data as CSV format
- Add ExportView with UI for data export using ShareLink
- Add ExportServiceTests for unit testing export functionality
- Update RootView to integrate the export feature

### GitHub Copilot Configuration
- Migrate .chatmode.md files to .agent.md format under .github/agents/
- Update copilot-instructions.md with project guidelines
- Update VS Code settings for the new agent configuration

## Testing
- Unit tests added for ExportService
- Manual testing performed for export functionality