### PR TITLE
feat: Enable horizontal scrolling for growth charts

### DIFF
--- a/app-ios/BabyMeasure/Localizable.xcstrings
+++ b/app-ios/BabyMeasure/Localizable.xcstrings
@@ -877,53 +877,53 @@
         }
       }
     },
-    "growthchart.range.all" : {
+    "growthchart.range.month" : {
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "All"
+            "value" : "By Month"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "全部"
+            "value" : "按月"
           }
         }
       }
     },
-    "growthchart.range.recent.1year" : {
+    "growthchart.range.week" : {
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Recent 1 Year"
+            "value" : "By Week"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "近1年"
+            "value" : "按周"
           }
         }
       }
     },
-    "growthchart.range.recent.3months" : {
+    "growthchart.range.year" : {
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Recent 3 Months"
+            "value" : "By Year"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "近3个月"
+            "value" : "按年"
           }
         }
       }

--- a/app-ios/BabyMeasure/Measurements/GrowthChartView.swift
+++ b/app-ios/BabyMeasure/Measurements/GrowthChartView.swift
@@ -5,20 +5,20 @@ import SwiftData
 import SwiftUI
 
 enum ChartRange: String, CaseIterable, Identifiable {
-  case recent3Months
-  case recent1Year
-  case all
+  case week
+  case month
+  case year
 
   var id: String { rawValue }
 
   var displayName: LocalizedStringKey {
     switch self {
-    case .recent3Months:
-      "growthchart.range.recent.3months"
-    case .recent1Year:
-      "growthchart.range.recent.1year"
-    case .all:
-      "growthchart.range.all"
+    case .week:
+      "growthchart.range.week"
+    case .month:
+      "growthchart.range.month"
+    case .year:
+      "growthchart.range.year"
     }
   }
 }
@@ -31,7 +31,7 @@ struct GrowthChartView: View {
   @Query private var measurements: [MeasurementEntity]
 
   @State private var selectedType: MeasurementType = .height
-  @State private var selectedRange: ChartRange = .recent3Months
+  @State private var selectedRange: ChartRange = .month
   @State private var standardSeries: [PercentileSeries] = []
   @State private var scrollPosition: Double?
 
@@ -104,8 +104,7 @@ struct GrowthChartView: View {
     .accessibilityLabel(Text("growthchart.empty.title"))
   }
 
-  @ViewBuilder
-  private var chartView: some View {
+  @ViewBuilder private var chartView: some View {
     let chart = makeChart()
       .chartForegroundStyleScale(percentileColors)
       .chartXAxis { xAxisMarks }
@@ -203,9 +202,9 @@ struct GrowthChartView: View {
 
   private var visibleDomainLength: Double? {
     switch selectedRange {
-    case .recent3Months: 90
-    case .recent1Year: 365
-    case .all: nil
+    case .week: 7
+    case .month: 31
+    case .year: 365
     }
   }
 

--- a/app-ios/BabyMeasure/Measurements/GrowthChartView.swift
+++ b/app-ios/BabyMeasure/Measurements/GrowthChartView.swift
@@ -33,6 +33,7 @@ struct GrowthChartView: View {
   @State private var selectedType: MeasurementType = .height
   @State private var selectedRange: ChartRange = .recent3Months
   @State private var standardSeries: [PercentileSeries] = []
+  @State private var scrollPosition: Double?
 
   init(child: ChildEntity) {
     self.child = child
@@ -82,8 +83,12 @@ struct GrowthChartView: View {
     .task(id: selectedType) {
       await updateChartData()
     }
-    .task(id: selectedRange) {
-      await updateChartData()
+    .onChange(of: selectedRange) {
+      if let age = daysSinceBirth(date: Date()) {
+        withAnimation {
+          scrollPosition = age
+        }
+      }
     }
     .onAppear {
       Task { await updateChartData() }
@@ -99,15 +104,34 @@ struct GrowthChartView: View {
     .accessibilityLabel(Text("growthchart.empty.title"))
   }
 
+  @ViewBuilder
   private var chartView: some View {
-    makeChart()
+    let chart = makeChart()
       .chartForegroundStyleScale(percentileColors)
       .chartXAxis { xAxisMarks }
       .chartYAxis { yAxisMarks }
-      .padding()
-      .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
-      .accessibilityElement(children: .contain)
-      .accessibilityLabel(Text("growthchart.title"))
+      .chartScrollableAxes(.horizontal)
+
+    Group {
+      if let length = visibleDomainLength {
+        if let scrollPosition = Binding($scrollPosition) {
+          chart.chartXVisibleDomain(length: length)
+            .chartScrollPosition(x: scrollPosition)
+        } else {
+          chart.chartXVisibleDomain(length: length)
+        }
+      } else {
+        if let scrollPosition = Binding($scrollPosition) {
+          chart.chartScrollPosition(x: scrollPosition)
+        } else {
+          chart
+        }
+      }
+    }
+    .padding()
+    .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
+    .accessibilityElement(children: .contain)
+    .accessibilityLabel(Text("growthchart.title"))
   }
 
   private func makeChart() -> some View {
@@ -177,6 +201,14 @@ struct GrowthChartView: View {
     measurements.filter { $0.typeRaw == selectedType.rawValue }
   }
 
+  private var visibleDomainLength: Double? {
+    switch selectedRange {
+    case .recent3Months: 90
+    case .recent1Year: 365
+    case .all: nil
+    }
+  }
+
   private func daysSinceBirth(date: Date) -> Double? {
     let calendar = Calendar.current
     let components = calendar.dateComponents([.day], from: child.birthday, to: date)
@@ -208,29 +240,10 @@ struct GrowthChartView: View {
   }
 
   private func updateChartData() async {
-    // Calculate range
-    let calendar = Calendar.current
     let now = Date()
-    let minDate: Date = switch selectedRange {
-    case .recent3Months:
-      calendar.date(byAdding: .month, value: -3, to: now) ?? now
-    case .recent1Year:
-      calendar.date(byAdding: .year, value: -1, to: now) ?? now
-    case .all:
-      child.birthday
-    }
-
-    // Determine min and max age in days for the chart x-axis
-    // We want to cover the selected range, but relative to the child's age.
-
-    // If "Recent 3 Months", we want [Now - 3 months, Now] converted to Age.
-    // But if the child is only 1 month old, we start from 0.
-
-    let startAgeDays = max(0, daysSinceBirth(date: minDate) ?? 0)
+    // Always fetch from birth (0) to now so we can scroll back
+    let startAgeDays = 0.0
     let endAgeDays = max(startAgeDays + 1, daysSinceBirth(date: now) ?? 0)
-
-    // If "All", we go from 0 to current age (or max measurement age)
-    // Let's just use the calculated start/end based on the time range.
 
     // Ensure we have a valid gender
     let gender = Gender(rawValue: child.genderRaw ?? "") ?? .unspecified
@@ -254,6 +267,9 @@ struct GrowthChartView: View {
 
     await MainActor.run {
       standardSeries = series
+      if scrollPosition == nil {
+        scrollPosition = endAgeDays
+      }
     }
   }
 }


### PR DESCRIPTION
## Description
This PR enables horizontal scrolling for growth charts and aligns the chart ranges with scrollable windows.

## Changes
- Enable horizontal scrolling for growth charts.
- Align growth chart ranges with scrollable windows.

## Context
These changes improve the user experience when viewing growth charts by allowing users to scroll through the data and ensuring the ranges are correctly aligned.
